### PR TITLE
Bugfix: Carousel button highlights and styles

### DIFF
--- a/client/modules/IDE/activities/activity00.jsx
+++ b/client/modules/IDE/activities/activity00.jsx
@@ -5,6 +5,7 @@ import Figure1 from './images/activity00_figure1.png';
 import Figure2 from './images/activity00_figure2.png';
 import RightArrowIcon from '../../../images/right-arrow.svg';
 import LeftArrowIcon from '../../../images/left-arrow.svg';
+import SquareIcon from '../../../images/stop.svg';
 
 export default function Activity00() {
   return (
@@ -15,30 +16,42 @@ export default function Activity00() {
         showStatus={false}
         renderArrowPrev={(onClickHandler, hasPrev, label) =>
           hasPrev && (
-            <button
-              type="button"
-              onClick={onClickHandler}
-              title={label}
+            <LeftArrowIcon
               className="arrow"
               style={{ left: 15 }}
-            >
-              <LeftArrowIcon focusable="false" aria-hidden="true" />
-            </button>
+              onClick={onClickHandler}
+              focusable="false"
+              aria-hidden="true"
+            />
           )
         }
         renderArrowNext={(onClickHandler, hasNext, label) =>
           hasNext && (
-            <button
-              type="button"
-              onClick={onClickHandler}
-              title={label}
+            <RightArrowIcon
               className="arrow"
               style={{ right: 15 }}
-            >
-              <RightArrowIcon focusable="false" aria-hidden="true" />
-            </button>
+              onClick={onClickHandler}
+              focusable="false"
+              aria-hidden="true"
+            />
           )
         }
+        renderIndicator={(onClickHandler, isSelected, index, label) => {
+          if (isSelected) {
+            return (
+              <SquareIcon className="indicator" style={{ color: '#8f8f8f' }} />
+            );
+          }
+          return (
+            <SquareIcon
+              className="indicator"
+              onClick={onClickHandler}
+              value={index}
+              key={index}
+              focusable="false"
+            />
+          );
+        }}
       >
         <div className="carouselItem">
           <h3> Attach the flower piece to see the flower </h3>

--- a/client/modules/IDE/pages/PuzzleView.jsx
+++ b/client/modules/IDE/pages/PuzzleView.jsx
@@ -4,11 +4,6 @@ import Activity00 from '../activities/activity00';
 const PuzzleView = () => (
   <div className="puzzle-view-container">
     <Activity00 />
-    <button type="button" className="nextButton">
-      <div>
-        <h2> Next activity </h2>
-      </div>
-    </button>
   </div>
 );
 

--- a/client/styles/components/_puzzle.scss
+++ b/client/styles/components/_puzzle.scss
@@ -30,8 +30,16 @@
     position: absolute;
     z-index: 2;
     top: calc(50% - 15px);
-    width: 50px;
-    height: 50px;
+    width: 30px;
+    height: 30px;
+}
+
+.indicator {
+    color: #ededed;
+    width: 10;
+    height: 10;
+    display: inline-block;
+    margin: 0 8px;
 }
 
 .nextButton {


### PR DESCRIPTION
* removing highlight styles for buttons on the carousel
* updating the style of the indicators to see better
* removing unused and incorrectly placed 'next activity' button

<img width="705" alt="image" src="https://github.com/ceciliahollins/p5.js-web-editor/assets/78127114/52a89ac4-6b7b-4708-9d25-f2a88508ea62">

